### PR TITLE
Expose sampling method in module, along with methods for gathering the data.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,13 @@
 {
   "name": "usb-power-profiling",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "usb-power-profiling",
+      "version": "1.1.0",
+      "license": "MPL-2.0",
       "dependencies": {
         "crc-full": "^1.1.0",
         "node-hid": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "powerz",
+  "name": "usb-power-profiling",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usb-power-profiling",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Make USB power meters usable with the Firefox Profiler",
   "homepage": "https://github.com/fqueze/usb-power-profiling/",
   "repository": "github:fqueze/usb-power-profiling",

--- a/usb-power-profiling.js
+++ b/usb-power-profiling.js
@@ -1247,6 +1247,7 @@ function profileFromData() {
 }
 
 function getPowerData(start, end) {
+  let timeStart = parseFloat(start) - startTime;
   let timeEnd = parseFloat(end) - startTime;
   if (timeEnd < 0) {
     throw "The requested end time is before this instance of the script was started."
@@ -1256,7 +1257,6 @@ function getPowerData(start, end) {
   for (let device of gDevices) {
     const {samples, sampleTimes, deviceName} = device;
 
-    let timeStart = parseFloat(start) - startTime;
     let startIndex = 0;
     while (sampleTimes[startIndex] < timeStart) {
       ++startIndex;

--- a/usb-power-profiling.js
+++ b/usb-power-profiling.js
@@ -1247,6 +1247,11 @@ function profileFromData() {
 }
 
 function getPowerData(start, end) {
+  let timeEnd = parseFloat(end) - startTime;
+  if (timeEnd < 0) {
+    throw "The requested end time is before this instance of the script was started."
+  }
+
   let counters = [];
   for (let device of gDevices) {
     const {samples, sampleTimes, deviceName} = device;
@@ -1255,12 +1260,6 @@ function getPowerData(start, end) {
     let startIndex = 0;
     while (sampleTimes[startIndex] < timeStart) {
       ++startIndex;
-    }
-
-    let timeEnd = parseFloat(end) - startTime;
-    if (timeEnd < 0) {
-      throw "The requested end time is before this instance of the script was started."
-      return;
     }
 
     let endIndex = startIndex;


### PR DESCRIPTION
This patch adds dedicated methods for starting and stopping the collection server. This was needed because as a module, usb-power-profiling starts up once it's imported when we might not want it to.

The changes keep the same behaviour when running the script directly from node locally, and now supports using two functions `runPowerCollectionServer`, and `stopPowerCollectionServer` from a module to start/stop the collection.

You can find an example of it being used here: https://github.com/gmierz/browsertime/commit/2fb2afbc16b79e0bb3ff1079fd322b772a79219c