### PR TITLE
Expose a stopSampling module method.

### DIFF
--- a/usb-power-profiling.js
+++ b/usb-power-profiling.js
@@ -410,7 +410,7 @@ ShizukuDevice.prototype = {
         payload[1] != 0 ||   // ?? Maybe this was a 16 bit value.
         payload[2] != this.samplingRequestId ||
         payload[3] != 0) { // Seems to be 0x80 for replies and 0 otherwise.
-      console.log("ignoring unexpected payload", payload);
+      console.log("ignoring unexpected payload", payload, JSON.stringify(this.expectedReplies));
       if (nextData) {
         DEBUG_log("processing next data");
         this.ondata(nextData);
@@ -440,12 +440,6 @@ ShizukuDevice.prototype = {
 
   async startSampling() {
     this.deviceName = this.deviceName.replace(/ in Application Mode$/, "");
-
-    try {
-      await resetDevice(this.device);
-    } catch(e) {
-      // resetDevice already logs the error.
-    }
 
     try {
       [this.endPointIn, this.endPointOut] = findBulkInOutEndPoints(this.device);
@@ -1128,6 +1122,14 @@ async function startSampling() {
   }
 }
 
+async function stopSampling() {
+  if (gDevices.length == 0) {
+    console.log("No device found");
+  } else {
+    await Promise.all(gDevices.map(d => d.stopSampling()));
+  }
+}
+
 var initialized = false;
 
 function initialize() {
@@ -1452,6 +1454,7 @@ if (require.main === module) {
 
 module.exports = {
   startSampling,
+  stopSampling,
   getPowerData,
   resetPowerData,
   profileFromData

--- a/usb-power-profiling.js
+++ b/usb-power-profiling.js
@@ -442,6 +442,12 @@ ShizukuDevice.prototype = {
     this.deviceName = this.deviceName.replace(/ in Application Mode$/, "");
 
     try {
+      await resetDevice(this.device);
+    } catch(e) {
+      // resetDevice already logs the error.
+    }
+
+    try {
       [this.endPointIn, this.endPointOut] = findBulkInOutEndPoints(this.device);
     } catch(e) {
       console.log(e);

--- a/usb-power-profiling.js
+++ b/usb-power-profiling.js
@@ -1148,9 +1148,7 @@ function initialize() {
       return;
     }
     gClosing = true;
-    if (gDevices.length > 0) {
-      await Promise.all(gDevices.map(d => d.stopSampling()));
-    }
+    await stopSampling();
     process.exit();
   });
 


### PR DESCRIPTION
This patch adds a `stopSampling` call that gets used to stop the device from sampling once a test run is done. This prevents a situation where the Shizuku device is already producing samples when we call `startSampling` and the shutdown command's reply is consumed as an unexpected response which then prevents sampling from starting again. This happens because the `ondata` call happens before the `sendCommand` call has a chance to setup the expected replies for the shutdown call.

At the same time, the `resetDevice` call is removed from the Shizuku device as it can cause issues in certain environments (LIBUSB_ERROR_NOT_FOUND).