### PR TITLE
Change the 'is-ready' message after profiler changed its postMessage API

### DIFF
--- a/index.html
+++ b/index.html
@@ -359,7 +359,7 @@ footer img {
 
       let isReady = false;
       window.addEventListener("message", function listener(event) {
-        if (event.data && event.data.name === "is-ready") {
+        if (event.data && event.data.name === "ready:response") {
           window.removeEventListener("message", listener);
           isReady = true;
           const message = {
@@ -375,7 +375,7 @@ footer img {
         if (isReady) {
           break;
         }
-        profilerWindow.postMessage({ name: "is-ready" }, origin);
+        profilerWindow.postMessage({ name: "ready:request" }, origin);
       }
     }
 


### PR DESCRIPTION
This is changed in https://github.com/firefox-devtools/profiler/pull/5148. Previously we were using 'is-ready' for both the request and the response. Now we are using two distinct messages on both for clarity.